### PR TITLE
Feature: Implement Stop Event

### DIFF
--- a/fmplayer/events.py
+++ b/fmplayer/events.py
@@ -56,6 +56,14 @@ class EventHandler(object):
         self.redis.set('fm:player:current', uri)
         self.player.play(uri)
 
+    def stop(self, data):
+        """ Handles the stop event. This triggered when a track should be
+        skipped during playback and the next track should be played.
+        """
+
+        logger.debug('Stop current track')
+        self.player.stop()
+
     def end(self, uri):
         """ Handles the end event. This is triggered directly by the queue
         watcher.
@@ -138,6 +146,7 @@ def event_watcher(redis, player, handler):
     events = {
         'pause': handler.pause,
         'resume': handler.resume,
+        'stop': handler.stop,
         'set_volume': handler.set_volume,
         'set_mute': handler.set_mute,
     }

--- a/fmplayer/events.py
+++ b/fmplayer/events.py
@@ -48,6 +48,7 @@ class EventHandler(object):
         """ Handles the play event, this is called directly by the player
         queue watcher.
         """
+
         self.redis.publish(self.channel, json.dumps({
             'event': 'play',
             'uri': uri
@@ -60,7 +61,9 @@ class EventHandler(object):
         watcher.
         """
 
+        logger.debug('Remove current track')
         self.redis.delete('fm:player:current')
+        logger.debug('Publish end event')
         self.redis.publish(self.channel, json.dumps({
             'event': 'end',
             'uri': uri
@@ -173,6 +176,7 @@ def queue_watcher(redis, handler):
             handler.play(uri)
             logger.debug('Waiting for {0} to Finish'.format(uri))
             STOP_EVENT.wait()
+            logger.debug('Fire end event')
             handler.end(uri)
 
         gevent.sleep(random.randint(0, 2) * 0.001)

--- a/fmplayer/player.py
+++ b/fmplayer/player.py
@@ -104,7 +104,7 @@ class Player(object):
         and the ``STOP_EVENT`` is set to ``True``.
         """
 
-        logger.debug('Track End - Unloading')
+        logger.debug('Track End - Unload')
         session.player.unload()
         logger.debug('STOP_EVENT set')
         STOP_EVENT.set()  # Unblocks the playlist watcher
@@ -130,6 +130,15 @@ class Player(object):
         else:
             logger.debug('STOP_EVENT cleared')
             STOP_EVENT.clear()  # Reset STOP_EVENT flag to False
+
+    def stop(self):
+        """ Stop the current playing track by stopping, and un loading.
+        """
+
+        logger.debug('Track Stop - Unload')
+        self.session.player.unload()
+        logger.debug('STOP_EVENT set')
+        STOP_EVENT.set()  # Unblocks the playlist watcher
 
     def pause(self):
         """ Pauses the current playback if the track is in a playing state.


### PR DESCRIPTION
This PR watches the `stop` event on the redis channel. This is triggered by the API when the current track should be skipped which is in Spotify lib terms is a stop as the track needs to be unloaded.
