### PR TITLE
Fix: Better play error handling and logging

### DIFF
--- a/fmplayer/player.py
+++ b/fmplayer/player.py
@@ -137,9 +137,10 @@ class Player(object):
         """
 
         if session is None:
-            session = self.session.player.unload()
+            session = self.session
 
         logger.info('Track Stop - Unload')
+        session.player.unload()
         logger.debug('Unblock Watcher: STOP_EVENT set')
         STOP_EVENT.set()
 


### PR DESCRIPTION
This PR tweaks the logic around handling errors with playing tracks. Currently I have no idea what happens when a track fails to play so it will now log all exceptions so I can see whats going on and wrote better code around handling those exceptions.

Basically we will always block when we try and play a track, on the event of an exception we will follow the normal stop procedure which unloads the track and unblocks the watcher and should then play the next track and log the exception that occurred.
