### PR TITLE
Feature: Volume Ranges

### DIFF
--- a/fmplayer/cli.py
+++ b/fmplayer/cli.py
@@ -107,7 +107,7 @@ def player(*args, **kwargs):
 
     # Create Handler Instance
     handler = EventHandler(redis, player, channel)
-    handler.set_volume({'volume': 80})  # Default volume
+    handler.set_volume({'volume': 60})  # Default volume
     handler.set_mute({'mute': False})  # Default mute off
 
     # Threads - Queue and Event Watcher

--- a/fmplayer/cli.py
+++ b/fmplayer/cli.py
@@ -8,15 +8,19 @@ fmplayer.cli
 CLI interface for FM Player.
 """
 
-import click
-import gevent
+# Standard Libs
 import logging
 import urlparse
 
+# Third Party Libs
+import click
+import gevent
 from gevent import monkey
-from fmplayer.player import Player
-from fmplayer.events import EventHandler, event_watcher, queue_watcher
 from redis import StrictRedis
+
+# First Party Libs
+from fmplayer.events import EventHandler, event_watcher, queue_watcher
+from fmplayer.player import Player
 
 
 monkey.patch_all()
@@ -71,6 +75,8 @@ logger.addHandler(handler)
     '-s',
     type=click.Choice(['alsa', 'fake']))
 @click.option('--mixer', '-m')
+@click.option('--min_vol', type=int)
+@click.option('--max_vol', type=int)
 @click.command()
 def player(*args, **kwargs):
     """FM Player is the thisissoon.fm Player software.
@@ -103,7 +109,9 @@ def player(*args, **kwargs):
         kwargs.pop('spotify_pass'),
         kwargs.pop('spotify_key'),
         kwargs.pop('audio_sink'),
-        kwargs.pop('mixer'))
+        kwargs.pop('mixer'),
+        kwargs.pop('min_vol'),
+        kwargs.pop('max_vol'))
 
     # Create Handler Instance
     handler = EventHandler(redis, player, channel)

--- a/fmplayer/player.py
+++ b/fmplayer/player.py
@@ -218,30 +218,6 @@ class Player(object):
 
         return alsaaudio.Mixer(control=self.mixer, cardindex=0)
 
-    def get_volume(self):
-        """ Returns the current mixer volume. Adapted from:
-        https://github.com/mopidy/mopidy-alsamixer
-
-        Returns
-        -------
-        int
-            The volume level from 0 to 100
-        """
-
-        try:
-            mixer = self.get_mixer()
-        except alsaaudio.ALSAAudioError:
-            return None
-
-        channels = mixer.getvolume()
-        if not channels:
-            return None
-        elif channels.count(channels[0]) == len(channels):
-            return int(channels[0])
-        else:
-            # Not all channels have the same volume
-            return None
-
     def set_volume(self, v):
         """ Set the player audio volume between 0 and 100.
 

--- a/fmplayer/player.py
+++ b/fmplayer/player.py
@@ -29,7 +29,7 @@ class Player(object):
     # Default Mixer Name
     mixer = 'PCM'
 
-    def __init__(self, user, password, key, sink, mixer):
+    def __init__(self, user, password, key, sink, mixer=None):
         """ Initialises the Spotify Session, logs the user in and starts
         the session event loop. The player does not manage state, it simply
         cares about playing music.
@@ -47,6 +47,9 @@ class Player(object):
         mixer : str
             Mixer Name
         """
+
+        if mixer is not None:
+            self.mixer = mixer
 
         # Session Configuration
         logger.debug('Configuring Spotify Session')

--- a/fmplayer/player.py
+++ b/fmplayer/player.py
@@ -8,11 +8,15 @@ fmplayer.player
 Classes and methods for running the Spotify player.
 """
 
-import alsaaudio
+# Standard Libs
 import logging
-import spotify
 import threading
 
+# Third Party Libs
+import alsaaudio
+import spotify
+
+# First Party Libs
 from fmplayer.sinks import FakeSink
 
 
@@ -26,10 +30,7 @@ class Player(object):
     """ Handles playing music from Spotify.
     """
 
-    # Default Mixer Name
-    mixer = 'PCM'
-
-    def __init__(self, user, password, key, sink, mixer=None):
+    def __init__(self, user, password, key, sink, mixer='PCM', min_vol=0, max_vol=100):
         """ Initialises the Spotify Session, logs the user in and starts
         the session event loop. The player does not manage state, it simply
         cares about playing music.
@@ -45,11 +46,19 @@ class Player(object):
         sink : str
             The audio sink to use
         mixer : str
-            Mixer Name
+            Mixer Name, default PCM
+        min_vol : int
+            Min volume level, default 0
+        max_vol : int
+            Max volume level, default 100
         """
 
-        if mixer is not None:
-            self.mixer = mixer
+        # Mixer
+        self.mixer = mixer
+
+        # Volume Levels
+        self.min_vol = min_vol
+        self.max_vol = max_vol
 
         # Session Configuration
         logger.debug('Configuring Spotify Session')
@@ -233,13 +242,15 @@ class Player(object):
             # Not all channels have the same volume
             return None
 
-    def set_volume(self, volume):
+    def set_volume(self, v):
         """ Set the player audio volume between 0 and 100.
 
         Arguments
         ---------
-        volume : int
-            The level to set the volume at
+        v : int
+            The level to set the volume at, this should be between 0 and 100
+            This will be recalculated to the actual volume percentage to set
+            based on the min and max volume levels.
         """
 
         try:
@@ -247,11 +258,19 @@ class Player(object):
         except alsaaudio.ALSAAudioError:
             return None
 
-        if volume >= 0 and volume <= 100:
-            mixer.setvolume(int(volume))
-            logger.debug('Set volume level to {0}'.format(volume))
-        else:
-            logger.error('{0} is not a valid volume level'.format(volume))
+        if not v >= 0 and not v <= 100:
+            logger.error('{0} is not a valid volume level'.format(v))
+            return None
+
+        # Convert the raw volume percentage into a percentage within the
+        # min and max volume ranges
+        volume = v * int(round(((self.max_vol - self.min_vol) / 100) + self.min_vol))
+
+        # Set the level
+        logger.debug('Set volume level to {0}'.format(volume))
+        mixer.setvolume(volume)
+
+        return volume
 
     def get_mute(self):
         """ Returns the current mute state of the player. Amended from:


### PR DESCRIPTION
This PR implements converting volume from 0/100 to volume percentages based on volume ranges.
### Example

```
max = 68
min = 18
volume = 50

volume * ((max - min) / 100) + min 

= 43%
```

This means the FE and API can continue to send values between 0>100 and the player handles the conversion.

Related issues:
- thisissoon/FM-API#26
- thisissoon/FM-Frontend#73
